### PR TITLE
Fixes a typo 

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         <h3>Prerequisites</h3>
         <ul>
           <li>Familarity with Rails is expected. No prior knoweldge of React is required.</li>
-          <li>Attendees are expected to bring laptos setup with Rails.</li>
+          <li>Attendees are expected to bring their laptops setup with Rails.</li>
         </ul>
         <hr>
         <h2>Instructors</h2>


### PR DESCRIPTION
This PR fixes a typo around the usage of the word `laptop` that comes under the details section of the React on rails workshop .
